### PR TITLE
Update test.cpp

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -14,7 +14,6 @@
 
 #include "xtalcomp.h"
 
-#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -335,18 +334,18 @@ bool hexagonalCellTest()
 
   std::vector<XcVector> pos1;
   pos1.reserve(12);
-  pos1.push_back(XcVector( 0.33333,  0.66667,  0.56072));
-  pos1.push_back(XcVector( 0.66667,  0.33333,  0.43928));
-  pos1.push_back(XcVector( 0.66667,  0.33333,  0.06072));
-  pos1.push_back(XcVector( 0.33333,  0.66667,  0.93928));
-  pos1.push_back(XcVector( 0.16448,  0.83552,  0.25000));
-  pos1.push_back(XcVector( 0.83552,  0.16448,  0.75000));
-  pos1.push_back(XcVector( 0.00000,  0.00000,  0.00000));
-  pos1.push_back(XcVector( 0.00000,  0.00000,  0.50000));
-  pos1.push_back(XcVector( 0.16448,  0.32896,  0.25000));
-  pos1.push_back(XcVector( 0.83552,  0.67104,  0.75000));
-  pos1.push_back(XcVector( 0.67104,  0.83552,  0.25000));
-  pos1.push_back(XcVector( 0.32896,  0.16448,  0.75000));
+  pos1.push_back(XcVector( 0.33333, 0.66667, 0.56072));
+  pos1.push_back(XcVector( 0.66667, 0.33333, 0.43928));
+  pos1.push_back(XcVector( 0.66667, 0.33333, 0.06072));
+  pos1.push_back(XcVector( 0.33333, 0.66667, 0.93928));
+  pos1.push_back(XcVector( 0.16448, 0.83552, 0.25000));
+  pos1.push_back(XcVector( 0.83552, 0.16448, 0.75000));
+  pos1.push_back(XcVector( 0.00000, 0.00000, 0.00000));
+  pos1.push_back(XcVector( 0.00000, 0.00000, 0.50000));
+  pos1.push_back(XcVector( 0.16448, 0.32896, 0.25000));
+  pos1.push_back(XcVector( 0.83552, 0.67104, 0.75000));
+  pos1.push_back(XcVector( 0.67104, 0.83552, 0.25000));
+  pos1.push_back(XcVector( 0.32896, 0.16448, 0.75000));
 
   std::vector<unsigned int> types1;
   types1.reserve(12);
@@ -359,7 +358,7 @@ bool hexagonalCellTest()
   types1.push_back(2);
   types1.push_back(2);
   types1.push_back(3);
-  types1.push_back(3);
+  types1.push_back(3);  
   types1.push_back(3);
   types1.push_back(3);
 
@@ -368,10 +367,11 @@ bool hexagonalCellTest()
   std::swap(pos2[4], pos2[8]);
   std::swap(pos2[5], pos2[9]);
   std::vector<unsigned int> types2 (types1);
-
+ 
   bool match = XtalComp::compare(cell1, types1, pos1,
                                  cell2, types2, pos2,
                                  NULL, 0.05, 0.25);
+
   if (!match)
     return false;
 
@@ -380,6 +380,99 @@ bool hexagonalCellTest()
   match = XtalComp::compare(cell1, types1, pos1,
                             cell2, types2, pos2,
                             NULL, 0.05, 0.25);
+  if (match)
+    return false;
+
+  return true;
+}
+
+// Test for a bug in which XtalComp rotated atoms so that, after wrapping,
+// some of them overlapped. Then, both atoms were matched to the same atom
+// in the reference xtal which resulted in a false positive.
+bool atomsOverlapping()
+{
+  XcMatrix cell1 ( 5.79828, 0.0, 0.0, 0.0, 5.79828, 0.0, 0.0, 0.0, 8.2 );
+  XcMatrix cell2 (cell1);
+
+  std::vector<XcVector> pos1;
+  pos1.reserve(20);
+
+  pos1.push_back(XcVector(0.0, 0.0, 0.0));
+  pos1.push_back(XcVector(0.0, 0.0, 0.5));
+  pos1.push_back(XcVector(0.5, 0.5, 0.0));
+  pos1.push_back(XcVector(0.5, 0.5, 0.5));
+  pos1.push_back(XcVector(0.5, 0.0, 0.25));
+  pos1.push_back(XcVector(0.5, 0.0, 0.75));
+  pos1.push_back(XcVector(0.0, 0.5, 0.25));
+  pos1.push_back(XcVector(0.0, 0.5, 0.75));
+  pos1.push_back(XcVector(0.25, 0.25, 0.25));
+  pos1.push_back(XcVector(0.25, 0.25, 0.75));
+  pos1.push_back(XcVector(0.25, 0.75, 0.25));
+  pos1.push_back(XcVector(0.25, 0.75, 0.75));
+  pos1.push_back(XcVector(0.75, 0.25, 0.25));
+  pos1.push_back(XcVector(0.75, 0.25, 0.75));
+  pos1.push_back(XcVector(0.75, 0.75, 0.25));
+  pos1.push_back(XcVector(0.75, 0.75, 0.75));
+  pos1.push_back(XcVector(0.5, 0.0, 0.0));
+  pos1.push_back(XcVector(0.5, 0.0, 0.5));
+  pos1.push_back(XcVector(0.0, 0.5, 0.0));
+  pos1.push_back(XcVector(0.0, 0.5, 0.5));
+
+  std::vector<XcVector> pos2;
+  pos2.reserve(20);
+
+  pos2.push_back(XcVector(0.0, 0.0, 0.0));
+  pos2.push_back(XcVector(0.0, 0.0, 0.5));
+  pos2.push_back(XcVector(0.5, 0.5, 0.0));
+  pos2.push_back(XcVector(0.5, 0.5, 0.5));
+  pos2.push_back(XcVector(0.5, 0.0, 0.25));
+  pos2.push_back(XcVector(0.5, 0.0, 0.75));
+  pos2.push_back(XcVector(0.0, 0.5, 0.25));
+  pos2.push_back(XcVector(0.0, 0.5, 0.75));
+  pos2.push_back(XcVector(0.25, 0.25, 0.25));
+  pos2.push_back(XcVector(0.25, 0.25, 0.75));
+  pos2.push_back(XcVector(0.25, 0.75, 0.25));
+  pos2.push_back(XcVector(0.75, 0.25, 0.25));
+  pos2.push_back(XcVector(0.75, 0.75, 0.25));
+  pos2.push_back(XcVector(0.75, 0.75, 0.75));
+  pos2.push_back(XcVector(0.5, 0.0, 0.0));
+  pos2.push_back(XcVector(0.0, 0.5, 0.0));
+  pos2.push_back(XcVector(0.25, 0.75, 0.75));
+  pos2.push_back(XcVector(0.75, 0.25, 0.75));
+  pos2.push_back(XcVector(0.5, 0.0, 0.5));
+  pos2.push_back(XcVector(0.0, 0.5, 0.5));
+
+  std::vector<unsigned int> types1;
+  types1.reserve(20);
+
+  types1.push_back(1);
+  types1.push_back(1);
+  types1.push_back(1);
+  types1.push_back(1);
+  types1.push_back(2);
+  types1.push_back(2);
+  types1.push_back(2);
+  types1.push_back(2);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(3);
+  types1.push_back(4);
+  types1.push_back(4);
+  types1.push_back(4);
+  types1.push_back(4);
+
+
+  std::vector<unsigned int> types2 (types1);
+
+  bool match = XtalComp::compare(cell2, types2, pos2,
+                                 cell1, types1, pos1,
+                                 NULL, 0.05, 0.25);
+
   if (match)
     return false;
 
@@ -399,6 +492,7 @@ int main()
           successes, failures);
   runTest(&allOfTheAbove, "All of the above test", successes, failures);
   runTest(&hexagonalCellTest, "Hexagonal cell test", successes, failures);
+  runTest(&atomsOverlapping, "Atoms Overlapping Test", successes, failures);
 
   return failures;
 }


### PR DESCRIPTION
Bug fix for overlapping atoms (after wrapping) producing false matches.

This includes a test which produces the overlapping atoms issue.
