### PR TITLE
Install and shared object target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,16 @@
 cmake_minimum_required (VERSION 2.6)
 project (XtalComp)
 
-add_library (XtalComp xtalcomp.cpp xctransform.cpp xcvector.h xcmatrix.h
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_library (XtalComp STATIC xtalcomp.cpp xctransform.cpp xcvector.h xcmatrix.h
   stablecomparison.h)
 
+add_library (XtalCompShared SHARED xtalcomp.cpp xctransform.cpp xcvector.h xcmatrix.h
+stablecomparison.h)
+set_target_properties(XtalCompShared PROPERTIES OUTPUT_NAME XtalComp)
+
 target_link_libraries(XtalComp spglib)
+target_link_libraries(XtalCompShared spglib)
 
 add_subdirectory(spglib)
 
@@ -18,3 +24,6 @@ endif(BUILD_CGI)
 
 add_executable (test test.cpp)
 target_link_libraries (test XtalComp)
+
+install(TARGETS XtalComp XtalCompShared LIBRARY DESTINATION "lib" ARCHIVE DESTINATION "lib")
+install(FILES "xcmatrix.h" "xctransform.h" "xcvector.h" "xtalcomp.h" DESTINATION "include/xtalcomp")


### PR DESCRIPTION
For certain applications it would be useful to have a shared library version of XtalComp. In addition, we find it useful if there is a *install* target such that when one types
```bash
make install
```
the library and headers are placed in a standard location. On unix based systems this would be */usr/local/lib* and */usr/local/include.*

With the changes introduced to *CMakeLists.txt* a shared library is created in addition to a static and an install target is created. To access the header files in an application one would then write
```cpp
#include <xtalcomp/xtalcomp.h>
```