### PR TITLE
Added tests for Craig Fisher examples

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -478,6 +478,227 @@ bool atomsOverlapping()
   return true;
 }
 
+// This tests some cases where Craig Fisher reported that reversing the order
+// of the POSCARs into XtalComp gives different results.
+bool craigFisherTest()
+{
+  // The formula for all 4 of these is Al1Si35
+  std::vector<unsigned int> types(36, 14);
+  types[0] = 13;
+
+  std::vector<XcVector> pos1, pos2, pos3, pos4;
+  pos1.reserve(36);
+  pos2.reserve(36);
+  pos3.reserve(36);
+  pos4.reserve(36);
+
+  // structure05.vasp
+  XcMatrix cell1(18.1260000000000012,  0.0000000000000000, 0.0000000000000000,
+                 -9.0629999999999971, 15.6975764689967363, 0.0000000000000000,
+                  0.0000000000000000,  0.0000000000000000, 7.5670000000000002);
+
+  pos1.push_back(XcVector(0.2635000000000000, 0.9041000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.1648000000000000, 0.4982000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.0959000000000000, 0.3594000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.5018000000000000, 0.6666666666666666, 0.2030000));
+  pos1.push_back(XcVector(0.6405999999999999, 0.7365000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.3333333333333333, 0.8352000000000001, 0.2030000));
+  pos1.push_back(XcVector(0.8352000000000001, 0.5018000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.9041000000000000, 0.6405999999999999, 0.5000000));
+  pos1.push_back(XcVector(0.4982000000000000, 0.3333333333333333, 0.2030000));
+  pos1.push_back(XcVector(0.3594000000000000, 0.2635000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.6666666666666666, 0.1648000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.7365000000000000, 0.0959000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.5018000000000000, 0.8352000000000001, 0.2030000));
+  pos1.push_back(XcVector(0.6405999999999999, 0.9041000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.3333333333333333, 0.4982000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.2635000000000000, 0.3594000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.1648000000000000, 0.6666666666666666, 0.2030000));
+  pos1.push_back(XcVector(0.0959000000000000, 0.7365000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.4982000000000000, 0.1648000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.3594000000000000, 0.0959000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.6666666666666666, 0.5018000000000000, 0.2030000));
+  pos1.push_back(XcVector(0.7365000000000000, 0.6405999999999999, 0.5000000));
+  pos1.push_back(XcVector(0.8352000000000001, 0.3333333333333333, 0.2030000));
+  pos1.push_back(XcVector(0.9041000000000000, 0.2635000000000000, 0.5000000));
+  pos1.push_back(XcVector(0.8352000000000001, 0.5018000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.4982000000000000, 0.3333333333333333, 0.7970000));
+  pos1.push_back(XcVector(0.6666666666666666, 0.1648000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.1648000000000000, 0.4982000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.5018000000000000, 0.6666666666666666, 0.7970000));
+  pos1.push_back(XcVector(0.3333333333333333, 0.8352000000000001, 0.7970000));
+  pos1.push_back(XcVector(0.4982000000000000, 0.1648000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.6666666666666666, 0.5018000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.8352000000000001, 0.3333333333333333, 0.7970000));
+  pos1.push_back(XcVector(0.5018000000000000, 0.8352000000000001, 0.7970000));
+  pos1.push_back(XcVector(0.3333333333333333, 0.4982000000000000, 0.7970000));
+  pos1.push_back(XcVector(0.1648000000000000, 0.6666666666666666, 0.7970000));
+
+  // structure05-niggli.vasp
+  XcMatrix cell2(0.00000000000000,   0.00000000000000, 7.56700000000000,
+                 9.06300000000000, -15.69757600000000, 0.00000000000000,
+                 9.06300000000000,  15.69757600000000, 0.00000000000000);
+
+  pos2.push_back(XcVector(0.50000, -0.64060, 0.26350));
+  pos2.push_back(XcVector(0.20300, -0.33340, 0.16480));
+  pos2.push_back(XcVector(0.50000, -0.26350, 0.09590));
+  pos2.push_back(XcVector(0.20300, -0.16487, 0.50180));
+  pos2.push_back(XcVector(0.50000, -0.09590, 0.64060));
+  pos2.push_back(XcVector(0.20300, -0.50187, 0.33333));
+  pos2.push_back(XcVector(0.20300,  0.33340, 0.83520));
+  pos2.push_back(XcVector(0.50000,  0.26350, 0.90410));
+  pos2.push_back(XcVector(0.20300,  0.16487, 0.49820));
+  pos2.push_back(XcVector(0.50000,  0.09590, 0.35940));
+  pos2.push_back(XcVector(0.20300,  0.50187, 0.66667));
+  pos2.push_back(XcVector(0.50000,  0.64060, 0.73650));
+  pos2.push_back(XcVector(0.20300, -0.33340, 0.50180));
+  pos2.push_back(XcVector(0.50000, -0.26350, 0.64060));
+  pos2.push_back(XcVector(0.20300, -0.16487, 0.33333));
+  pos2.push_back(XcVector(0.50000, -0.09590, 0.26350));
+  pos2.push_back(XcVector(0.20300, -0.50187, 0.16480));
+  pos2.push_back(XcVector(0.50000, -0.64060, 0.09590));
+  pos2.push_back(XcVector(0.20300,  0.33340, 0.49820));
+  pos2.push_back(XcVector(0.50000,  0.26350, 0.35940));
+  pos2.push_back(XcVector(0.20300,  0.16487, 0.66667));
+  pos2.push_back(XcVector(0.50000,  0.09590, 0.73650));
+  pos2.push_back(XcVector(0.20300,  0.50187, 0.83520));
+  pos2.push_back(XcVector(0.50000,  0.64060, 0.90410));
+  pos2.push_back(XcVector(0.79700,  0.33340, 0.83520));
+  pos2.push_back(XcVector(0.79700,  0.16487, 0.49820));
+  pos2.push_back(XcVector(0.79700,  0.50187, 0.66667));
+  pos2.push_back(XcVector(0.79700, -0.33340, 0.16480));
+  pos2.push_back(XcVector(0.79700, -0.16487, 0.50180));
+  pos2.push_back(XcVector(0.79700, -0.50187, 0.33333));
+  pos2.push_back(XcVector(0.79700,  0.33340, 0.49820));
+  pos2.push_back(XcVector(0.79700,  0.16487, 0.66667));
+  pos2.push_back(XcVector(0.79700,  0.50187, 0.83520));
+  pos2.push_back(XcVector(0.79700, -0.33340, 0.50180));
+  pos2.push_back(XcVector(0.79700, -0.16487, 0.33333));
+  pos2.push_back(XcVector(0.79700, -0.50187, 0.16480));
+
+  // structure07.vasp
+  XcMatrix cell3(18.1260000000000012,  0.0000000000000000, 0.0000000000000000,
+                 -9.0629999999999971, 15.6975764689967363, 0.0000000000000000,
+                  0.0000000000000000,  0.0000000000000000, 7.5670000000000002);
+
+  pos3.push_back(XcVector(0.9041000000000000, 0.6405999999999999, 0.500000000));
+  pos3.push_back(XcVector(0.2635000000000000, 0.9041000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.1648000000000000, 0.4982000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.0959000000000000, 0.3594000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.5018000000000000, 0.6666666666666666, 0.203000000));
+  pos3.push_back(XcVector(0.6405999999999999, 0.7365000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.3333333333333333, 0.8352000000000001, 0.203000000));
+  pos3.push_back(XcVector(0.8352000000000001, 0.5018000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.4982000000000000, 0.3333333333333333, 0.203000000));
+  pos3.push_back(XcVector(0.3594000000000000, 0.2635000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.6666666666666666, 0.1648000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.7365000000000000, 0.0959000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.5018000000000000, 0.8352000000000001, 0.203000000));
+  pos3.push_back(XcVector(0.6405999999999999, 0.9041000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.3333333333333333, 0.4982000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.2635000000000000, 0.3594000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.1648000000000000, 0.6666666666666666, 0.203000000));
+  pos3.push_back(XcVector(0.0959000000000000, 0.7365000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.4982000000000000, 0.1648000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.3594000000000000, 0.0959000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.6666666666666666, 0.5018000000000000, 0.203000000));
+  pos3.push_back(XcVector(0.7365000000000000, 0.6405999999999999, 0.500000000));
+  pos3.push_back(XcVector(0.8352000000000001, 0.3333333333333333, 0.203000000));
+  pos3.push_back(XcVector(0.9041000000000000, 0.2635000000000000, 0.500000000));
+  pos3.push_back(XcVector(0.8352000000000001, 0.5018000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.4982000000000000, 0.3333333333333333, 0.797000000));
+  pos3.push_back(XcVector(0.6666666666666666, 0.1648000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.1648000000000000, 0.4982000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.5018000000000000, 0.6666666666666666, 0.797000000));
+  pos3.push_back(XcVector(0.3333333333333333, 0.8352000000000001, 0.797000000));
+  pos3.push_back(XcVector(0.4982000000000000, 0.1648000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.6666666666666666, 0.5018000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.8352000000000001, 0.3333333333333333, 0.797000000));
+  pos3.push_back(XcVector(0.5018000000000000, 0.8352000000000001, 0.797000000));
+  pos3.push_back(XcVector(0.3333333333333333, 0.4982000000000000, 0.797000000));
+  pos3.push_back(XcVector(0.1648000000000000, 0.6666666666666666, 0.797000000));
+
+  // structure07-niggli.vasp
+  XcMatrix cell4(0.00000000000000,   0.00000000000000, 7.56700000000000,
+                 9.06300000000000, -15.69757600000000, 0.00000000000000,
+                 9.06300000000000,  15.69757600000000, 0.00000000000000);
+
+  pos4.push_back(XcVector(0.50000,  0.26350, 0.90410));
+  pos4.push_back(XcVector(0.20300, -0.33340, 0.16480));
+  pos4.push_back(XcVector(0.50000, -0.26350, 0.09590));
+  pos4.push_back(XcVector(0.20300, -0.16487, 0.50180));
+  pos4.push_back(XcVector(0.50000, -0.09590, 0.64060));
+  pos4.push_back(XcVector(0.20300, -0.50187, 0.33333));
+  pos4.push_back(XcVector(0.50000, -0.64060, 0.26350));
+  pos4.push_back(XcVector(0.20300,  0.33340, 0.83520));
+  pos4.push_back(XcVector(0.20300,  0.16487, 0.49820));
+  pos4.push_back(XcVector(0.50000,  0.09590, 0.35940));
+  pos4.push_back(XcVector(0.20300,  0.50187, 0.66667));
+  pos4.push_back(XcVector(0.50000,  0.64060, 0.73650));
+  pos4.push_back(XcVector(0.20300, -0.33340, 0.50180));
+  pos4.push_back(XcVector(0.50000, -0.26350, 0.64060));
+  pos4.push_back(XcVector(0.20300, -0.16487, 0.33333));
+  pos4.push_back(XcVector(0.50000, -0.09590, 0.26350));
+  pos4.push_back(XcVector(0.20300, -0.50187, 0.16480));
+  pos4.push_back(XcVector(0.50000, -0.64060, 0.09590));
+  pos4.push_back(XcVector(0.20300,  0.33340, 0.49820));
+  pos4.push_back(XcVector(0.50000,  0.26350, 0.35940));
+  pos4.push_back(XcVector(0.20300,  0.16487, 0.66667));
+  pos4.push_back(XcVector(0.50000,  0.09590, 0.73650));
+  pos4.push_back(XcVector(0.20300,  0.50187, 0.83520));
+  pos4.push_back(XcVector(0.50000,  0.64060, 0.90410));
+  pos4.push_back(XcVector(0.79700,  0.33340, 0.83520));
+  pos4.push_back(XcVector(0.79700,  0.16487, 0.49820));
+  pos4.push_back(XcVector(0.79700,  0.50187, 0.66667));
+  pos4.push_back(XcVector(0.79700, -0.33340, 0.16480));
+  pos4.push_back(XcVector(0.79700, -0.16487, 0.50180));
+  pos4.push_back(XcVector(0.79700, -0.50187, 0.33333));
+  pos4.push_back(XcVector(0.79700,  0.33340, 0.49820));
+  pos4.push_back(XcVector(0.79700,  0.16487, 0.66667));
+  pos4.push_back(XcVector(0.79700,  0.50187, 0.83520));
+  pos4.push_back(XcVector(0.79700, -0.33340, 0.50180));
+  pos4.push_back(XcVector(0.79700, -0.16487, 0.33333));
+  pos4.push_back(XcVector(0.79700, -0.50187, 0.16480));
+
+  // Store pointers to these to simplify test code, since we need to
+  // test every combination.
+  std::vector<XcMatrix*> cells;
+  cells.push_back(&cell1);
+  cells.push_back(&cell2);
+  cells.push_back(&cell3);
+  cells.push_back(&cell4);
+
+  std::vector<std::vector<XcVector>*> positions;
+  positions.push_back(&pos1);
+  positions.push_back(&pos2);
+  positions.push_back(&pos3);
+  positions.push_back(&pos4);
+
+  // We need to test every combination, including swapping the order
+  bool anyFailures = false;
+  for (size_t i = 0; i < 4; ++i) {
+    for (size_t j = 0; j < 4; ++j) {
+      if (i == j)
+        continue;
+
+      bool match = XtalComp::compare(*cells[i], types, *positions[i],
+                                     *cells[j], types, *positions[j],
+                                     NULL, 0.05, 0.25);
+
+      if (!match) {
+        fprintf(stdout, "'%s' failed for comparison: '%lu' with '%lu'\n",
+                __FUNCTION__, i + 1, j + 1);
+        anyFailures = true;
+      }
+    }
+  }
+
+  if (anyFailures)
+    return false;
+
+  return true;
+}
+
 int main()
 {
   int failures = 0;
@@ -492,6 +713,7 @@ int main()
   runTest(&allOfTheAbove, "All of the above test", successes, failures);
   runTest(&hexagonalCellTest, "Hexagonal cell test", successes, failures);
   runTest(&atomsOverlapping, "Atoms Overlapping Test", successes, failures);
+  runTest(&craigFisherTest, "Craig Fisher Test", successes, failures);
 
   return failures;
 }


### PR DESCRIPTION
These tests verify that a bug that Craig Fisher noticed has been
fixed.

The bug involved changing the order of XtalComp input and getting
a different result. The bug was caused by precision for checking
atoms on the cell boundaries.